### PR TITLE
Adding back in the longitude and latitude text boxes.

### DIFF
--- a/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
+++ b/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
@@ -137,6 +137,9 @@ function (
             // Clear search box
             this.searchTextbox.set("value", '');
 
+            // Clear coordinate text boxes
+            this._setLongitudeAndLatitudeTextBox('', '');
+
             // Remove the map marker, if any
             if (this._marker) {
                 this._marker.setMap(null);
@@ -388,6 +391,8 @@ function (
             // Set the marker's position and coordinate textboxes, unless marker is ignored (for example when setting to default coordiantes)
             if (!skipMarker) {
 
+                this._setLongitudeAndLatitudeTextBox(location.lng(), location.lat());
+
                 if (!this._marker) { // No marker yet, create one
                     this._marker = new google.maps.Marker({
                         map: this._map
@@ -446,6 +451,18 @@ function (
             location = new google.maps.LatLng(latitude, longitude);
 
             this._setMapLocation(location, null, true, false);
+            this._setLongitudeAndLatitudeTextBox(longitude, latitude);
+        },
+
+        /**
+         * Sets the value of the longitude and latitude text boxes.
+         * @param {any} longitude
+         * @param {any} latitude
+         * @returns
+         */
+        _setLongitudeAndLatitudeTextBox: function (longitude, latitude) {
+            this.longitudeTextbox.set('value', longitude);
+            this.latitudeTextbox.set('value', latitude);
         },
 
         /**

--- a/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.html
+++ b/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.html
@@ -10,4 +10,8 @@
 
     <div class="google-maps-editor-map-canvas dijitTextBox" data-dojo-attach-point="canvas"></div>
 
+    <div class="dijitInputContainer editor-map-coordinates">
+        <input type="text" disabled placeholder="${_localized.latitude}" title="${_localized.latitude}" data-dojo-type="dijit/form/TextBox" data-dojo-attach-point="latitudeTextbox" />
+        <input type="text" disabled placeholder="${_localized.longitude}" title="${_localized.longitude}" data-dojo-type="dijit/form/TextBox" data-dojo-attach-point="longitudeTextbox" />
+    </div>
 </div>


### PR DESCRIPTION
Hello.

Previously, the Google maps editor had a feature where it showed textboxes which contained the latitude and longitude of the currently selected location. I cannot find any release notes to reference this being removed or why it was removed, but it seems to have been taken out after version 2.0.0.20.

There may be a very good reason this was taken out that I'm unaware of, but it was useful functionality.

I have created a fork of this repository and put this functionality back into place as best as I can replicate. Would this be something you'd want to add back in to the main repo? Please let me know, and any feedback would be much appreciated.

All the best,
Connor