### PR TITLE
Refactor place search using AutocompleteSuggestion and Advanced Markers

### DIFF
--- a/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
+++ b/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
@@ -47,13 +47,3 @@
 .dijitDialogPaneContentArea .google-maps-editor .dijitTextBox { width: 100% }
 .dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-help { top: 5px; }
 .dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-clear { top: 9.5px }
-
-.dijitDialogPaneContentArea .google-maps-editor-tools gmp-place-autocomplete {
-    width: 100% !important;
-}
-
-.dijitDialogPaneContentArea .google-maps-editor-tools gmp-place-autocomplete input {
-    height: 30px !important;
-    min-height: 30px !important;
-    padding: 4px 70px 4px 8px !important;
-}

--- a/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
+++ b/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
@@ -1,10 +1,59 @@
-﻿.google-maps-editor-map-canvas {width: 100%; height: 240px; margin: 2px 0 5px 0}
+.google-maps-editor-map-canvas {width: 100%; height: 240px; margin: 2px 0 5px 0}
 .google-maps-editor-tools { position: relative; width: 100%; max-width: 632px; }
 .google-maps-editor-tools a { display: block; position: absolute; right: 0; top: 9.5px; right: 7px }
 .google-maps-editor-tools a.google-maps-editor-map-clear { right: 34px; top: 13.5px; transform: scale(120%) }
+
+/* Suggestions dropdown styling */
+.google-maps-suggestions-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    background-color: #ffffff;
+    border: 1px solid #b3b3b3;
+    border-top: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    max-height: 300px;
+    overflow-y: auto;
+    z-index: 1000;
+}
+
+.google-maps-suggestions-dropdown .suggestion-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #000000;
+    font-size: 13px;
+    font-family: inherit;
+}
+
+.google-maps-suggestions-dropdown .suggestion-item:hover,
+.google-maps-suggestions-dropdown .suggestion-item.selected {
+    background-color: #f5f5f5;
+}
+
+.google-maps-suggestions-dropdown .suggestion-item:last-child {
+    border-bottom: none;
+}
 
 /* On-page edit popup */
 .dijitDialogPaneContentArea .google-maps-editor { width: 400px}
 .dijitDialogPaneContentArea .google-maps-editor .dijitTextBox { width: 100% }
 .dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-help { top: 5px; }
 .dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-clear { top: 9.5px }
+
+.dijitDialogPaneContentArea .google-maps-editor-tools gmp-place-autocomplete {
+    width: 100% !important;
+}
+
+.dijitDialogPaneContentArea .google-maps-editor-tools gmp-place-autocomplete input {
+    height: 30px !important;
+    min-height: 30px !important;
+    padding: 4px 70px 4px 8px !important;
+}

--- a/GoogleMapsEditor/GoogleMapsEditor.csproj
+++ b/GoogleMapsEditor/GoogleMapsEditor.csproj
@@ -1,100 +1,100 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Condition="'$(Configuration)' == 'Release'" Project="BuildAddonZipFile.proj" />
-	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<OutputType>Library</OutputType>
-		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<FileVersion>4.0.0.4</FileVersion>
-		<InformationalVersion>Optimizely CMS 12</InformationalVersion>
-		<Title>Google Maps Editor for Optimizely</Title>
-		<Description>Editor for setting coordinates using Google Maps.</Description>
-		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-	<!-- Properties affecting NuGet package, i.e. equivalents of .nuspec properties -->
-	<PropertyGroup>
-		<Product>$(Title)</Product>
-		<PackageDescription>$(Description)</PackageDescription>
-		<Version>$(FileVersion)</Version>
-		<PackageVersion>$(FileVersion)</PackageVersion>
-		<!-- Append "-name-of-pre-release" to build prerelease version of packages, e.g. "$(FileVersion)-newfeature" -->
-		<PackageId>$(AssemblyName)</PackageId>
-		<Authors>ted&amp;gustaf</Authors>
-		<Copyright>© Ted &amp; Gustaf AB. All rights reserved.</Copyright>
-		<PackageProjectUrl>https://github.com/tedgustaf/optimizely-google-maps-editor</PackageProjectUrl>
-		<!-- Embedded icon doesn't yet work in some NuGet feeds, including the Optimizely feed -->
-		<PackageIcon>nuget-icon.png</PackageIcon>
-		<PackageIconUrl>https://github.com/tedgustaf/optimizely-google-maps-editor/blob/main/nuget-icon.png?raw=true</PackageIconUrl>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<PackageReleaseNotes>Fixed bug related to required properties.</PackageReleaseNotes>
-		<PackageTags>Optimizely</PackageTags>
-	</PropertyGroup>
-	<!-- Build NuGet package for release builds -->
-	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<PackageOutputPath>bin\Release</PackageOutputPath>
-	</PropertyGroup>
-	<!-- Delete existing NuGet package files -->
-	<Target
-	  Name="DeleteDebugSymbolFile"
-	  BeforeTargets="DispatchToInnerBuilds"
-	  Condition="'$(Configuration)' == 'Release'"
+  <Import Condition="'$(Configuration)' == 'Release'" Project="BuildAddonZipFile.proj" />
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <FileVersion>4.0.0.4</FileVersion>
+    <InformationalVersion>Optimizely CMS 12</InformationalVersion>
+    <Title>Google Maps Editor for Optimizely</Title>
+    <Description>Editor for setting coordinates using Google Maps.</Description>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <!-- Properties affecting NuGet package, i.e. equivalents of .nuspec properties -->
+  <PropertyGroup>
+    <Product>$(Title)</Product>
+    <PackageDescription>$(Description)</PackageDescription>
+    <Version>$(FileVersion)</Version>
+    <PackageVersion>$(FileVersion)</PackageVersion>
+    <!-- Append "-name-of-pre-release" to build prerelease version of packages, e.g. "$(FileVersion)-newfeature" -->
+    <PackageId>$(AssemblyName)</PackageId>
+    <Authors>ted&amp;gustaf</Authors>
+    <Copyright>© Ted &amp; Gustaf AB. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/tedgustaf/optimizely-google-maps-editor</PackageProjectUrl>
+    <!-- Embedded icon doesn't yet work in some NuGet feeds, including the Optimizely feed -->
+    <PackageIcon>nuget-icon.png</PackageIcon>
+    <PackageIconUrl>https://github.com/tedgustaf/optimizely-google-maps-editor/blob/main/nuget-icon.png?raw=true</PackageIconUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageReleaseNotes>Fixed bug related to required properties.</PackageReleaseNotes>
+    <PackageTags>Optimizely</PackageTags>
+  </PropertyGroup>
+  <!-- Build NuGet package for release builds -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageOutputPath>bin\Release</PackageOutputPath>
+  </PropertyGroup>
+  <!-- Delete existing NuGet package files -->
+  <Target
+    Name="DeleteDebugSymbolFile"
+    BeforeTargets="DispatchToInnerBuilds"
+    Condition="'$(Configuration)' == 'Release'"
   >
-		<Message Text="Deleting existing NuGet packages..." Importance="high" />
-		<ItemGroup>
-			<NuGetPackageFiles Include="bin/Release/*.nupkg" />
-		</ItemGroup>
-		<Delete Files="@(NuGetPackageFiles)" />
-	</Target>
-	<ItemGroup>
-		<None Include="BuildAddonZipFile.proj" />
-		<None Include="ClientResources\googlemaps\nls\Labels.js" />
-		<None Include="ClientResources\googlemaps\nls\sv\Labels.js" />
-		<None Include="ClientResources\googlemaps\WidgetTemplate.css" />
-		<None Include="ClientResources\googlemaps\WidgetTemplate.html" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.10.0,13)" />
-		<PackageReference Include="EPiServer.Framework" Version="[12.8.0,13)" />
-	</ItemGroup>
-	<!-- Include the icon, license, readme files, and build targets in the NuGet package -->
-	<ItemGroup>
-		<None Include="..\nuget-icon.png">
-			<Visible>False</Visible>
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="readme.md">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="readme.txt">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-		<None Include="GoogleMapsEditor.targets">
-			<Pack>True</Pack>
-			<PackagePath>build\net6.0</PackagePath>
-		</None>
-		<None Include="GoogleMapsEditor.targets">
-			<Pack>True</Pack>
-			<PackagePath>build\net7.0</PackagePath>
-		</None>
-		<None Include="GoogleMapsEditor.targets">
-			<Pack>True</Pack>
-			<PackagePath>build\net8.0</PackagePath>
-		</None>
-	</ItemGroup>
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-			<_Parameter1>Testsite</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
+    <Message Text="Deleting existing NuGet packages..." Importance="high" />
+    <ItemGroup>
+      <NuGetPackageFiles Include="bin/Release/*.nupkg" />
+    </ItemGroup>
+    <Delete Files="@(NuGetPackageFiles)" />
+  </Target>
+  <ItemGroup>
+    <None Include="BuildAddonZipFile.proj" />
+    <None Include="ClientResources\googlemaps\nls\Labels.js" />
+    <None Include="ClientResources\googlemaps\nls\sv\Labels.js" />
+    <None Include="ClientResources\googlemaps\WidgetTemplate.css" />
+    <None Include="ClientResources\googlemaps\WidgetTemplate.html" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.10.0,13)" />
+    <PackageReference Include="EPiServer.Framework" Version="[12.8.0,13)" />
+  </ItemGroup>
+  <!-- Include the icon, license, readme files, and build targets in the NuGet package -->
+  <ItemGroup>
+    <None Include="..\nuget-icon.png">
+      <Visible>False</Visible>
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="readme.md">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="readme.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+    <None Include="GoogleMapsEditor.targets">
+      <Pack>True</Pack>
+      <PackagePath>build\net6.0</PackagePath>
+    </None>
+    <None Include="GoogleMapsEditor.targets">
+      <Pack>True</Pack>
+      <PackagePath>build\net7.0</PackagePath>
+    </None>
+    <None Include="GoogleMapsEditor.targets">
+      <Pack>True</Pack>
+      <PackagePath>build\net8.0</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Testsite</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/GoogleMapsEditor/GoogleMapsEditor.csproj
+++ b/GoogleMapsEditor/GoogleMapsEditor.csproj
@@ -1,95 +1,100 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Condition="'$(Configuration)' == 'Release'" Project="BuildAddonZipFile.proj" />
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <OutputType>Library</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <FileVersion>4.0.0.5</FileVersion>
-    <InformationalVersion>Optimizely CMS 12</InformationalVersion>
-    <Title>Google Maps Editor for Optimizely</Title>
-    <Description>Editor for setting coordinates using Google Maps.</Description>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  <!-- Properties affecting NuGet package, i.e. equivalents of .nuspec properties -->
-  <PropertyGroup>
-    <Product>$(Title)</Product>
-    <PackageDescription>$(Description)</PackageDescription>
-    <Version>$(FileVersion)</Version>
-    <PackageVersion>$(FileVersion)</PackageVersion>
-    <!-- Append "-name-of-pre-release" to build prerelease version of packages, e.g. "$(FileVersion)-newfeature" -->
-    <PackageId>$(AssemblyName)</PackageId>
-    <Authors>ted&amp;gustaf</Authors>
-    <Copyright>© Ted &amp; Gustaf AB. All rights reserved.</Copyright>
-    <PackageProjectUrl>https://github.com/tedgustaf/optimizely-google-maps-editor</PackageProjectUrl>
-    <!-- Embedded icon doesn't yet work in some NuGet feeds, including the Optimizely feed -->
-    <PackageIcon>nuget-icon.png</PackageIcon>
-    <PackageIconUrl>https://github.com/tedgustaf/optimizely-google-maps-editor/blob/main/nuget-icon.png?raw=true</PackageIconUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <PackageReadmeFile>readme.md</PackageReadmeFile>
-    <PackageReleaseNotes>Fixed bug related to required properties.</PackageReleaseNotes>
-    <PackageTags>Optimizely</PackageTags>
-  </PropertyGroup>
-  <!-- Build NuGet package for release builds -->
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageOutputPath>bin\Release</PackageOutputPath>
-  </PropertyGroup>
-  <!-- Delete existing NuGet package files -->
-  <Target Name="DeleteDebugSymbolFile" BeforeTargets="DispatchToInnerBuilds" Condition="'$(Configuration)' == 'Release'">
-    <Message Text="Deleting existing NuGet packages..." Importance="high" />
-    <ItemGroup>
-      <NuGetPackageFiles Include="bin/Release/*.nupkg" />
-    </ItemGroup>
-    <Delete Files="@(NuGetPackageFiles)" />
-  </Target>
-  <ItemGroup>
-    <None Include="BuildAddonZipFile.proj" />
-    <None Include="ClientResources\googlemaps\nls\Labels.js" />
-    <None Include="ClientResources\googlemaps\nls\sv\Labels.js" />
-    <None Include="ClientResources\googlemaps\WidgetTemplate.html" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.10.0,13)" />
-    <PackageReference Include="EPiServer.Framework" Version="[12.8.0,13)" />
-  </ItemGroup>
-  <!-- Include the icon, license, readme files, and build targets in the NuGet package -->
-  <ItemGroup>
-    <None Include="..\nuget-icon.png">
-      <Visible>False</Visible>
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="readme.md">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="readme.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-    <None Include="GoogleMapsEditor.targets">
-      <Pack>True</Pack>
-      <PackagePath>build\net6.0</PackagePath>
-    </None>
-    <None Include="GoogleMapsEditor.targets">
-      <Pack>True</Pack>
-      <PackagePath>build\net7.0</PackagePath>
-    </None>
-    <None Include="GoogleMapsEditor.targets">
-      <Pack>True</Pack>
-      <PackagePath>build\net8.0</PackagePath>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Testsite</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+	<Import Condition="'$(Configuration)' == 'Release'" Project="BuildAddonZipFile.proj" />
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<FileVersion>4.0.0.4</FileVersion>
+		<InformationalVersion>Optimizely CMS 12</InformationalVersion>
+		<Title>Google Maps Editor for Optimizely</Title>
+		<Description>Editor for setting coordinates using Google Maps.</Description>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<!-- Properties affecting NuGet package, i.e. equivalents of .nuspec properties -->
+	<PropertyGroup>
+		<Product>$(Title)</Product>
+		<PackageDescription>$(Description)</PackageDescription>
+		<Version>$(FileVersion)</Version>
+		<PackageVersion>$(FileVersion)</PackageVersion>
+		<!-- Append "-name-of-pre-release" to build prerelease version of packages, e.g. "$(FileVersion)-newfeature" -->
+		<PackageId>$(AssemblyName)</PackageId>
+		<Authors>ted&amp;gustaf</Authors>
+		<Copyright>© Ted &amp; Gustaf AB. All rights reserved.</Copyright>
+		<PackageProjectUrl>https://github.com/tedgustaf/optimizely-google-maps-editor</PackageProjectUrl>
+		<!-- Embedded icon doesn't yet work in some NuGet feeds, including the Optimizely feed -->
+		<PackageIcon>nuget-icon.png</PackageIcon>
+		<PackageIconUrl>https://github.com/tedgustaf/optimizely-google-maps-editor/blob/main/nuget-icon.png?raw=true</PackageIconUrl>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<PackageReleaseNotes>Fixed bug related to required properties.</PackageReleaseNotes>
+		<PackageTags>Optimizely</PackageTags>
+	</PropertyGroup>
+	<!-- Build NuGet package for release builds -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<PackageOutputPath>bin\Release</PackageOutputPath>
+	</PropertyGroup>
+	<!-- Delete existing NuGet package files -->
+	<Target
+	  Name="DeleteDebugSymbolFile"
+	  BeforeTargets="DispatchToInnerBuilds"
+	  Condition="'$(Configuration)' == 'Release'"
+  >
+		<Message Text="Deleting existing NuGet packages..." Importance="high" />
+		<ItemGroup>
+			<NuGetPackageFiles Include="bin/Release/*.nupkg" />
+		</ItemGroup>
+		<Delete Files="@(NuGetPackageFiles)" />
+	</Target>
+	<ItemGroup>
+		<None Include="BuildAddonZipFile.proj" />
+		<None Include="ClientResources\googlemaps\nls\Labels.js" />
+		<None Include="ClientResources\googlemaps\nls\sv\Labels.js" />
+		<None Include="ClientResources\googlemaps\WidgetTemplate.css" />
+		<None Include="ClientResources\googlemaps\WidgetTemplate.html" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.10.0,13)" />
+		<PackageReference Include="EPiServer.Framework" Version="[12.8.0,13)" />
+	</ItemGroup>
+	<!-- Include the icon, license, readme files, and build targets in the NuGet package -->
+	<ItemGroup>
+		<None Include="..\nuget-icon.png">
+			<Visible>False</Visible>
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="readme.md">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="readme.txt">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+		<None Include="GoogleMapsEditor.targets">
+			<Pack>True</Pack>
+			<PackagePath>build\net6.0</PackagePath>
+		</None>
+		<None Include="GoogleMapsEditor.targets">
+			<Pack>True</Pack>
+			<PackagePath>build\net7.0</PackagePath>
+		</None>
+		<None Include="GoogleMapsEditor.targets">
+			<Pack>True</Pack>
+			<PackagePath>build\net8.0</PackagePath>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>Testsite</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/GoogleMapsEditor/GoogleMapsEditor.csproj
+++ b/GoogleMapsEditor/GoogleMapsEditor.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <FileVersion>4.0.0.4</FileVersion>
+    <FileVersion>4.0.0.5</FileVersion>
     <InformationalVersion>Optimizely CMS 12</InformationalVersion>
     <Title>Google Maps Editor for Optimizely</Title>
     <Description>Editor for setting coordinates using Google Maps.</Description>
@@ -38,11 +38,7 @@
     <PackageOutputPath>bin\Release</PackageOutputPath>
   </PropertyGroup>
   <!-- Delete existing NuGet package files -->
-  <Target
-    Name="DeleteDebugSymbolFile"
-    BeforeTargets="DispatchToInnerBuilds"
-    Condition="'$(Configuration)' == 'Release'"
-  >
+  <Target Name="DeleteDebugSymbolFile" BeforeTargets="DispatchToInnerBuilds" Condition="'$(Configuration)' == 'Release'">
     <Message Text="Deleting existing NuGet packages..." Importance="high" />
     <ItemGroup>
       <NuGetPackageFiles Include="bin/Release/*.nupkg" />
@@ -53,7 +49,6 @@
     <None Include="BuildAddonZipFile.proj" />
     <None Include="ClientResources\googlemaps\nls\Labels.js" />
     <None Include="ClientResources\googlemaps\nls\sv\Labels.js" />
-    <None Include="ClientResources\googlemaps\WidgetTemplate.css" />
     <None Include="ClientResources\googlemaps\WidgetTemplate.html" />
   </ItemGroup>
   <ItemGroup>

--- a/GoogleMapsEditor/GoogleMapsEditorDescriptor.cs
+++ b/GoogleMapsEditor/GoogleMapsEditorDescriptor.cs
@@ -13,6 +13,8 @@ public class GoogleMapsEditorDescriptor : EditorDescriptor
 
     public virtual string ApiKey { get; set; } = ServiceCollectionExtensions.ApiKey;
 
+    public virtual string MapId { get; set; } = ServiceCollectionExtensions.MapId;
+
     public virtual int DefaultZoom { get; set; } = ServiceCollectionExtensions.DefaultZoom;
 
     public virtual double DefaultLatitude { get; set; } = ServiceCollectionExtensions.DefaultLatitude;
@@ -25,6 +27,9 @@ public class GoogleMapsEditorDescriptor : EditorDescriptor
 
         // API key for the Google Maps JavaScript API
         metadata.EditorConfiguration.Add("apiKey", ApiKey);
+
+        // Map Id for the Google Maps JavaScript API
+        metadata.EditorConfiguration.Add("mapId", MapId);
 
         // Default zoom level from 1 (least) to 20 (most)
         // https://developers.google.com/maps/documentation/javascript/tutorial#zoom-levels

--- a/GoogleMapsEditor/ServiceCollectionExtensions.cs
+++ b/GoogleMapsEditor/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
     /// Gets or sets the API key to use for Google Maps.
     /// </summary>
     public static string ApiKey { get; set; }
+    
     /// <summary>
     /// Gets or sets the Map Id to use for Google Maps.
     /// </summary>

--- a/GoogleMapsEditor/ServiceCollectionExtensions.cs
+++ b/GoogleMapsEditor/ServiceCollectionExtensions.cs
@@ -14,6 +14,10 @@ public static class ServiceCollectionExtensions
     /// Gets or sets the API key to use for Google Maps.
     /// </summary>
     public static string ApiKey { get; set; }
+    /// <summary>
+    /// Gets or sets the Map Id to use for Google Maps.
+    /// </summary>
+    public static string MapId { get; set; }
 
     public static int DefaultZoom { get; set; }
 
@@ -27,13 +31,15 @@ public static class ServiceCollectionExtensions
     /// Enables the Google Maps Editor.
     /// </summary>
     /// <param name="apiKey">Google Maps API key</param>
+    /// <param name="mapId">Google Maps - Map ID</param>
     /// <param name="defaultZoom">Default zoom level from 1 (least) to 20 (most).</param>
     /// <param name="defaultLongitude">Default longitude coordinate when no property value is set.</param>
     /// <param name="defaultLatitude">Default latitude coordinate when no property value is set.</param>
     /// <param name="services"></param>
-    public static IServiceCollection AddGoogleMapsEditor(this IServiceCollection services, string apiKey, int defaultZoom = 5, double defaultLatitude = 59.33564361359625, double defaultLongitude = 18.03014159202576)
+    public static IServiceCollection AddGoogleMapsEditor(this IServiceCollection services, string apiKey, string mapId, int defaultZoom = 5, double defaultLatitude = 59.33564361359625, double defaultLongitude = 18.03014159202576)
     {
         ApiKey = apiKey;
+        MapId = mapId;
         DefaultZoom = defaultZoom;
         DefaultLongitude = defaultLongitude;
         DefaultLatitude = defaultLatitude;

--- a/Testsite/Startup.cs
+++ b/Testsite/Startup.cs
@@ -39,9 +39,10 @@ public class Startup
             .Configure<RazorPagesOptions>(x => x.RootDirectory = "/");
 
         // Enable the Google Maps Editor add-on if an API key has been specified
-        if (_configuration["GoogleMaps:ApiKey"] is string apiKey && !string.IsNullOrWhiteSpace(apiKey))
+        if (_configuration["GoogleMaps:ApiKey"] is string apiKey && !string.IsNullOrWhiteSpace(apiKey) 
+            && _configuration["GoogleMaps:MapId"] is string mapId && !string.IsNullOrWhiteSpace(mapId))
         {
-            services.AddGoogleMapsEditor(apiKey);
+            services.AddGoogleMapsEditor(apiKey, mapId);
 
             if (_webHostEnvironment.IsDevelopment())
             {


### PR DESCRIPTION
### Description

This PR fixes the place search issue caused by the legacy Google Places API, as mentioned in  
https://github.com/tedgustaf/optimizely-google-maps-editor/issues/7#issue-3448827303.

I refactored the place search to use **`AutocompleteSuggestion.fetchAutocompleteSuggestions`**, which aligns with the current Google Maps API. I also migrated markers to **Advanced Markers**, since the previous Marker API is deprecated.

With these changes, there are **no Google Maps warnings**, and everything works as expected. I’ve tested the editor locally and confirmed the behavior.

**Screenshots**

*No more warnings from Google Maps*
<img width="2555" height="1243" alt="No more warnings from Google Maps" src="https://github.com/user-attachments/assets/a9f40e47-f201-4ad3-a958-be3d596da381" />

*Autocomplete place search*
<img width="2553" height="1248" alt="Autocomplete place search" src="https://github.com/user-attachments/assets/e09979e5-2447-4930-b793-744ed84efb91" />

*End-to-end behavior: autocomplete selection updates the map and marker as expected.*
<img width="2556" height="1238" alt="End-to-end place search and marker behavior" src="https://github.com/user-attachments/assets/e23d68b2-ad21-4535-9a1f-29e1fba05951" />

Let me know if you need any additional info or adjustments.

Thanks!