### PR TITLE
Upgrade to Optimizely CMS 13 (.NET 10)

### DIFF
--- a/GoogleMapsEditor/BuildAddonZipFile.proj
+++ b/GoogleMapsEditor/BuildAddonZipFile.proj
@@ -4,33 +4,12 @@
 	<!-- Variables used in the MSBuild scripts -->
 	<PropertyGroup>
 		<PluginName>GoogleMapsEditor</PluginName>
-		<SolutionDir Condition="$(SolutionDir) == ''">$(MSBuildProjectDirectory)..\</SolutionDir>
+		<SolutionDir Condition="$(SolutionDir) == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), '..'))/</SolutionDir>
 		<TmpOutDir>$(ProjectDir)bin\addon</TmpOutDir>
 		<BinDir>$(ProjectDir)bin</BinDir>
 		<ObjDir>$(ProjectDir)obj</ObjDir>
+		<TmpZipDir>$([MSBuild]::NormalizePath($(SolutionDir), 'tmp'))</TmpZipDir>
 	</PropertyGroup>
-	
-	<!-- Creates a ZIP file containing a specified set of files -->
-	<UsingTask TaskName="ZipDirectory" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-		<ParameterGroup>
-			<InputPath ParameterType="System.String" Required="true" />
-			<OutputFileName ParameterType="System.String" Required="true" />
-			<OverwriteExistingFile ParameterType="System.Boolean" Required="false" />
-		</ParameterGroup>
-		<Task>
-			<Reference Include="System.IO.Compression.FileSystem" />
-			<Using Namespace="System.IO" />
-			<Using Namespace="System.IO.Compression" />
-			<Code Type="Fragment" Language="cs">
-				<![CDATA[        
-          if(this.OverwriteExistingFile) {
-            File.Delete(this.OutputFileName);
-          }
-          ZipFile.CreateFromDirectory(this.InputPath, this.OutputFileName);
-        ]]>
-			</Code>
-		</Task>
-	</UsingTask>
 
 	<Target Name="Clean" AfterTargets="AfterClean">
 		<Message Text="Cleaning project..." Importance="high" />
@@ -40,7 +19,7 @@
 
 	<!-- Include ZIP file, target (for copying ZIP to modules folder), and readme in package -->
 	<ItemGroup>
-		<None Include="$(SolutionDir)\tmp\$(PluginName).zip">
+		<None Include="$(TmpZipDir)\$(PluginName).zip">
 			<Pack>True</Pack>
 			<PackagePath>contentFiles\any\any\modules\_protected\GoogleMapsEditor</PackagePath>
 			<Visible>False</Visible>
@@ -50,7 +29,7 @@
 
 	<!-- Compiles files to include in release version of NuGet package, where add-on is packaged as a ZIP file -->
 	<!-- Run only once per build regardless of number of target frameworks -->
-	<Target Name="CompileReleaseAddonContent" BeforeTargets="DispatchToInnerBuilds">
+	<Target Name="CompileReleaseAddonContent" BeforeTargets="GenerateNuspec">
 
 		<Message Text="Compiling content for add-on zip file..." Importance="high" />
 
@@ -72,14 +51,14 @@
 		<!-- Update the module config with the version information -->
 		<XmlPoke XmlInputPath="$(TmpOutDir)\content\module.config" Query="/module/@clientResourceRelativePath" Value="$(FileVersion)" />
 
-		<!-- Create the Zip file -->
+		<!-- Create the Zip file using the built-in MSBuild ZipDirectory task (works on .NET Core MSBuild / Mac / Linux) -->
 		<Message Text="Creating add-on ZIP file..." Importance="high" />
 		
-		<MakeDir Directories="$(SolutionDir)\tmp" />
+		<MakeDir Directories="$(TmpZipDir)" />
 		
-		<ZipDirectory InputPath="$(TmpOutDir)\content" 
-					  OutputFileName="$(SolutionDir)\tmp\$(PluginName).zip" 
-					  OverwriteExistingFile="true" />
+		<ZipDirectory SourceDirectory="$(TmpOutDir)\content"
+		              DestinationFile="$(TmpZipDir)\$(PluginName).zip"
+		              Overwrite="true" />
 
 	</Target>
 

--- a/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
+++ b/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
@@ -48,6 +48,12 @@ function (
         _setValueAttr: function (/*anything*/ newValue, /*Boolean?*/ priorityChange) {
             this.inherited(arguments);
 
+            // Cache the contentTypeGuid supplied by CMS so it can be included in
+            // every value we post back (SystemTextBlockDataConverter requires it).
+            if (newValue && typeof newValue === "object" && newValue.contentTypeGuid) {
+                this._contentTypeGuid = newValue.contentTypeGuid;
+            }
+
             this.textbox.value = newValue || "";
 
             if (this._marker == null) // Initial load
@@ -346,6 +352,9 @@ function (
                         "latitude": null,
                         "longitude": null
                     };
+                    if (this._contentTypeGuid) {
+                        value.contentTypeGuid = this._contentTypeGuid;
+                    }
                 }
             }
             else { // Has a location
@@ -363,6 +372,9 @@ function (
                         "latitude": parseFloat(latitude),
                         "longitude": parseFloat(longitude)
                     };
+                    if (this._contentTypeGuid) {
+                        value.contentTypeGuid = this._contentTypeGuid;
+                    }
                 } else {
                     value = latitude + "," + longitude;
                 }

--- a/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
+++ b/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
@@ -54,7 +54,7 @@ function (
                 this._contentTypeGuid = newValue.contentTypeGuid;
             }
 
-            this.textbox.value = newValue || "";
+            this.textbox.value = typeof newValue === "string" ? newValue : "";
 
             if (this._marker == null) // Initial load
             {

--- a/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
+++ b/GoogleMapsEditor/ClientResources/googlemaps/Editor.js
@@ -46,7 +46,11 @@ function (
         templateString: template,
 
         _setValueAttr: function (/*anything*/ newValue, /*Boolean?*/ priorityChange) {
-            this.inherited(arguments);
+
+            // Pass priorityChange=false so Dijit's _handleOnChange never fires onChange
+            // on programmatic CMS value sets (undefined == null in JS loose equality).
+            // onChange is fired explicitly in _setCoordinatesValue for user interactions.
+            this.inherited(arguments, [newValue, false]);
 
             // Cache the contentTypeGuid supplied by CMS so it can be included in
             // every value we post back (SystemTextBlockDataConverter requires it).
@@ -59,10 +63,6 @@ function (
             if (this._marker == null) // Initial load
             {
                 this._refreshMarkerLocation();
-            }
-
-            if (this._isComplexType()) {
-                this.onChange(newValue); // Otherwise onChange won't trigger correctly for complex property types
             }
         },
 
@@ -382,6 +382,8 @@ function (
 
             // Set the widget (i.e. property) value and trigger change event to notify the CMS (and possibly others) that the value has changed
             this.set("value", value);
+
+            this.onChange(value);
         },
 
         /**

--- a/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
+++ b/GoogleMapsEditor/ClientResources/googlemaps/WidgetTemplate.css
@@ -1,10 +1,9 @@
-﻿.google-maps-editor-map-canvas {width: 100%; height: 240px; margin: 2px 0 5px 0}
-.google-maps-editor-tools { position: relative; width: 100%; max-width: 632px; }
-.google-maps-editor-tools a { display: block; position: absolute; right: 0; top: 9.5px; right: 7px }
-.google-maps-editor-tools a.google-maps-editor-map-clear { right: 34px; top: 13.5px; transform: scale(120%) }
+﻿.google-maps-editor-map-canvas { width: 100%; height: 240px; margin: 2px 0 5px 0 }
+.google-maps-editor-tools { position: relative; width: 100%; max-width: 632px; margin-bottom: 4px; }
+.google-maps-editor-tools .dijitTextBox { width: 100%; margin-bottom: 0; }
+.google-maps-editor-tools a { display: flex; position: absolute; right: 7px; top: 50%; transform: translateY(-50%) }
+.google-maps-editor-tools a.google-maps-editor-map-clear { right: 34px; transform: translateY(-50%) scale(120%) }
 
 /* On-page edit popup */
 .dijitDialogPaneContentArea .google-maps-editor { width: 400px}
 .dijitDialogPaneContentArea .google-maps-editor .dijitTextBox { width: 100% }
-.dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-help { top: 5px; }
-.dijitDialogPaneContentArea .google-maps-editor-tools a.google-maps-editor-map-clear { top: 9.5px }

--- a/GoogleMapsEditor/GoogleMapsEditor.csproj
+++ b/GoogleMapsEditor/GoogleMapsEditor.csproj
@@ -62,18 +62,22 @@
   </ItemGroup>
   <!-- Include the icon, license, readme files, and build targets in the NuGet package -->
   <ItemGroup>
-    <None Include="..\nuget-icon.png">
+    <None Include="../nuget-icon.png">
       <Visible>False</Visible>
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
-    <None Include="..\LICENSE">
+    <None Include="../LICENSE">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="readme.md">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="readme.txt">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="GoogleMapsEditor.targets">
       <Pack>True</Pack>

--- a/GoogleMapsEditor/GoogleMapsEditor.csproj
+++ b/GoogleMapsEditor/GoogleMapsEditor.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Condition="'$(Configuration)' == 'Release'" Project="BuildAddonZipFile.proj" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <FileVersion>4.0.0.4</FileVersion>
-    <InformationalVersion>Optimizely CMS 12</InformationalVersion>
+    <FileVersion>5.0.0</FileVersion>
+    <InformationalVersion>Optimizely CMS 13</InformationalVersion>
     <Title>Google Maps Editor for Optimizely</Title>
     <Description>Editor for setting coordinates using Google Maps.</Description>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -57,39 +57,27 @@
     <None Include="ClientResources\googlemaps\WidgetTemplate.html" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.10.0,13)" />
-    <PackageReference Include="EPiServer.Framework" Version="[12.8.0,13)" />
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[13.0.0,14)" />
+    <PackageReference Include="EPiServer.Framework" Version="[13.0.0,14)" />
   </ItemGroup>
   <!-- Include the icon, license, readme files, and build targets in the NuGet package -->
   <ItemGroup>
     <None Include="..\nuget-icon.png">
       <Visible>False</Visible>
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
     </None>
     <None Include="..\LICENSE">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
     </None>
     <None Include="readme.md">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
     </None>
     <None Include="readme.txt">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
     </None>
     <None Include="GoogleMapsEditor.targets">
       <Pack>True</Pack>
-      <PackagePath>build\net6.0</PackagePath>
-    </None>
-    <None Include="GoogleMapsEditor.targets">
-      <Pack>True</Pack>
-      <PackagePath>build\net7.0</PackagePath>
-    </None>
-    <None Include="GoogleMapsEditor.targets">
-      <Pack>True</Pack>
-      <PackagePath>build\net8.0</PackagePath>
+      <PackagePath>build\net10.0</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The website project was set up using the **Optimizely CMS empty** Visual Studio 
 1. Create an empty CMS database and update `appsettings.json` for the `Testsite` project (or run `create-db.bat` in the solution folder if you're using `LocalDB`) 
 1. Add a Google Maps API key to `appsettings.json` (or `appsettings.user.json`) for the `Testsite` project
 1. Start `Testsite` project and browse to https://localhost:44300/ which will prompt you to create an admin user
-1. Access the Optimizely UI through: https://localhost:44300/episerver/cms using the credentials of the admin user
+1. Access the Optimizely UI through: https://localhost:44300/optimizely/cms using the credentials of the admin user
 1. Create a new page of type `SamplePageType`
 1. Configure a site in Optimizely
 1. Test the Google Maps editor

--- a/Testsite/ListItemProperty.cs
+++ b/Testsite/ListItemProperty.cs
@@ -1,9 +1,9 @@
 ﻿using EPiServer.Core;
-using EPiServer.PlugIn;
+using EPiServer.DataAnnotations;
 
 namespace Testsite;
 
-[PropertyDefinitionTypePlugIn]
+[PropertyDefinitionType]
 public class ListItemProperty : PropertyList<ListItem>
 {
 

--- a/Testsite/SamplePageType.cs
+++ b/Testsite/SamplePageType.cs
@@ -16,7 +16,7 @@ public class SamplePageType : PageData
 
     public virtual GoogleMapsCoordinates? BlockCoordinates { get; set; }
 
-    [Display(GroupName = "Different tab", Description = "Required coordinates.")]
+    [Display(GroupName = "DifferentTab", Description = "Required coordinates.")]
     [Required]
     [UIHint(GoogleMapsEditorDescriptor.UIHint)]
     public virtual string? MoreStringCoordinates { get; set; }

--- a/Testsite/Startup.cs
+++ b/Testsite/Startup.cs
@@ -1,5 +1,5 @@
-using EPiServer.Cms.Shell;
 using EPiServer.Cms.UI.AspNetIdentity;
+using EPiServer.DependencyInjection;
 using EPiServer.Framework.Hosting;
 using EPiServer.Framework.Web.Resources;
 using EPiServer.Scheduler;
@@ -46,11 +46,11 @@ public class Startup
             if (_webHostEnvironment.IsDevelopment())
             {
                 // Configure site for add-ondevelopment, meaning files for the Google Maps Editor add-on will be loaded directly from its project folder.
-                var uiSolutionFolder = Path.Combine(_webHostEnvironment.ContentRootPath, @"..\");
+                var uiSolutionFolder = Path.Combine(_webHostEnvironment.ContentRootPath, "..");
 
                 services.Configure<CompositeFileProviderOptions>(c =>
                 {
-                    c.BasePathFileProviders.Add(new MappingPhysicalFileProvider($"/EPiServer/GoogleMapsEditor", string.Empty, Path.Combine(uiSolutionFolder, "GoogleMapsEditor")));
+                    c.BasePathFileProviders.Add(new MappingPhysicalFileProvider($"/Optimizely/GoogleMapsEditor", string.Empty, Path.Combine(uiSolutionFolder, "GoogleMapsEditor")));
                 });
             }
         }

--- a/Testsite/Testsite.csproj
+++ b/Testsite/Testsite.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EPiServer.CMS" Version="12.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.5" />
+    <PackageReference Include="EPiServer.CMS" Version="13.*" />
+    <PackageReference Include="EPiServer.CMS.UI.AspNetIdentity" Version="13.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GoogleMapsEditor\GoogleMapsEditor.csproj" />


### PR DESCRIPTION
## Upgrade to Optimizely CMS 13 (.NET 10)

This PR upgrades the GoogleMapsEditor add-on and its Testsite to Optimizely CMS 13 on .NET 10.

The version was bumped to **5.0.0**.

### Changes

#### Upgrade changes

- **Target framework**: `net6.0;net7.0;net8.0` → `net10.0`
- **Package references**: All EPiServer 12.* packages updated to 13.0.0+

#### Bug fixes

A few UI specific bugs needed to be fixed as a part of the upgrade:

- **`contentTypeGuid` round-tripping**: CMS 13's `SystemTextBlockDataConverter` requires `contentTypeGuid` to be present in block JSON. The widget now caches it on inbound values and includes it in every outbound value, preventing a *"Json block data model misses required field 'contentTypeGuid'"* warning
- **New list items disappearing in Visual Builder**: Dijit's `_handleOnChange` uses loose equality (`undefined == null`), causing `onChange` to fire on every programmatic CMS value set (e.g., new list item init), which caused newly-added list items to be immediately dropped. Fixed by always passing `priorityChange=false` to `this.inherited()`, and firing `this.onChange()` explicitly only from `_setCoordinatesValue` (i.e. real user interactions)
- **Object coercion in textbox**: `this.textbox.value` was being set to `"[object Object]"` for block-type properties. Fixed with an explicit `typeof` guard
- **Visual Builder styling**: Some minor UI tweaks to fix styling when using Visual Builder (text box width, button positions)

#### NuGet packaging (Mac/Linux compatibility)

- Replaced the `CodeTaskFactory`-based `ZipDirectory` task (not supported on .NET Core MSBuild) with the built-in MSBuild `ZipDirectory` task
- Fixed Windows-only backslash paths in `BuildAddonZipFile.proj` using `$([MSBuild]::NormalizePath(...))`
- Changed `BeforeTargets="DispatchToInnerBuilds"` → `BeforeTargets="GenerateNuspec"` (the former only fires for multi-TFM builds)
- Fixed some paths for cross-platform compatibility

#### Test site

- Also upgraded to CMS 13, with any breaking changes fixed

### Testing

Tested as per the README against the Testsite (using the `SamplePageType`).

Also packaged and installed to verify.

<img width="546" height="334" alt="image" src="https://github.com/user-attachments/assets/035a5216-d1c2-42df-b056-65c3045bd7ab" />


